### PR TITLE
Pass Arguments from Rookie Class to Super

### DIFF
--- a/weapons/verification/tests.py
+++ b/weapons/verification/tests.py
@@ -57,8 +57,8 @@ if not "Battle" in USER_GLOBAL:
 Battle = USER_GLOBAL['Battle']
 
 class Rookie(Warrior):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.health = 50
         self.attack = 1
 


### PR DESCRIPTION
Related with #5 

While checking the mission **the-weapons**, a TypeError ir raised in the test case number 10, due to the following line:

https://github.com/XanderVi/checkio-missions-set-war/blob/master/weapons/verification/tests.py#L611

This is my implementation of the method **add_units**:

``` python
    def add_units(self, cls, qty):
        for i in range(qty):
            print(cls)
            self.units.append(cls(army=self))
```

**cls** references the type of unit added to the army, and in the case of the Rookie (The secret class added in the tests), it does not expect an `army` keyword

I think this change should be propagated to all test files with the Rookie class, but I leave that to you.
Cheers!