### PR TITLE
Check if fight function is defined by the user

### DIFF
--- a/army_battles/verification/tests.py
+++ b/army_battles/verification/tests.py
@@ -22,6 +22,9 @@ if not "Battle" in USER_GLOBAL:
 
 Battle = USER_GLOBAL['Battle']
 
+if "fight" not in USER_GLOBAL:
+    raise NotImplementedError("Where is 'fight'?")
+
 fight = USER_GLOBAL['fight']
 """
 

--- a/defender/verification/tests.py
+++ b/defender/verification/tests.py
@@ -25,6 +25,9 @@ Defender = USER_GLOBAL['Defender']
 if not issubclass(Defender, Warrior):
     raise Warning("Defender should be the subclass of the Warrior")
 
+if "fight" not in USER_GLOBAL:
+    raise NotImplementedError("Where is 'fight'?")
+
 fight = USER_GLOBAL['fight']
 
 if not "Battle" in USER_GLOBAL:

--- a/healer/verification/tests.py
+++ b/healer/verification/tests.py
@@ -49,6 +49,9 @@ Healer = USER_GLOBAL['Healer']
 if not issubclass(Healer, Warrior):
     raise Warning("Healer should be the subclass of the Warrior")
 
+if "fight" not in USER_GLOBAL:
+    raise NotImplementedError("Where is 'fight'?")
+
 fight = USER_GLOBAL['fight']
 
 if not "Battle" in USER_GLOBAL:

--- a/lancer/verification/tests.py
+++ b/lancer/verification/tests.py
@@ -41,6 +41,9 @@ Lancer = USER_GLOBAL['Lancer']
 if not issubclass(Lancer, Warrior):
     raise Warning("Lancer should be the subclass of the Warrior")
 
+if "fight" not in USER_GLOBAL:
+    raise NotImplementedError("Where is 'fight'?")
+
 fight = USER_GLOBAL['fight']
 
 if not "Battle" in USER_GLOBAL:

--- a/straight_fight/verification/tests.py
+++ b/straight_fight/verification/tests.py
@@ -49,6 +49,9 @@ Healer = USER_GLOBAL['Healer']
 if not issubclass(Healer, Warrior):
     raise Warning("Healer should be the subclass of the Warrior")
 
+if "fight" not in USER_GLOBAL:
+    raise NotImplementedError("Where is 'fight'?")
+
 fight = USER_GLOBAL['fight']
 
 if not "Battle" in USER_GLOBAL:

--- a/vampire/verification/tests.py
+++ b/vampire/verification/tests.py
@@ -33,6 +33,9 @@ Vampire = USER_GLOBAL['Vampire']
 if not issubclass(Vampire, Warrior):
     raise Warning("Vampire should be the subclass of the Warrior")
 
+if "fight" not in USER_GLOBAL:
+    raise NotImplementedError("Where is 'fight'?")
+
 fight = USER_GLOBAL['fight']
 
 if not "Battle" in USER_GLOBAL:

--- a/warlords/verification/tests.py
+++ b/warlords/verification/tests.py
@@ -57,6 +57,9 @@ Warlord = USER_GLOBAL['Warlord']
 if not issubclass(Warlord, Warrior):
     raise Warning("Warlord should be the subclass of the Warrior")
 
+if "fight" not in USER_GLOBAL:
+    raise NotImplementedError("Where is 'fight'?")
+
 fight = USER_GLOBAL['fight']
 
 if not "Battle" in USER_GLOBAL:

--- a/warriors/verification/tests.py
+++ b/warriors/verification/tests.py
@@ -12,6 +12,9 @@ Knight = USER_GLOBAL['Knight']
 if not issubclass(Knight, Warrior):
     raise Warning("Knight should be the sublcass of the Warrior")
 
+if "fight" not in USER_GLOBAL:
+    raise NotImplementedError("Where is 'fight'?")
+
 fight = USER_GLOBAL['fight']
 """
 

--- a/weapons/verification/tests.py
+++ b/weapons/verification/tests.py
@@ -49,6 +49,9 @@ Healer = USER_GLOBAL['Healer']
 if not issubclass(Healer, Warrior):
     raise Warning("Healer should be the subclass of the Warrior")
 
+if "fight" not in USER_GLOBAL:
+    raise NotImplementedError("Where is 'fight'?")
+
 fight = USER_GLOBAL['fight']
 
 if not "Battle" in USER_GLOBAL:


### PR DESCRIPTION
After [this forum post](https://py.checkio.org/forum/post/14529/httpspycheckioorgmissionarmy-battlessolve/) where the user deleted the fight function (probably because it seemed to be not required for the mission), I found that the checker does not check if the fight function is still defined by the user. And since the error message was not helpful at all for the user to detect his/her own error, this fix is a "necessity".